### PR TITLE
Fix shortened decimal points in APY boost info

### DIFF
--- a/ui/pages/liquidity.tsx
+++ b/ui/pages/liquidity.tsx
@@ -190,12 +190,12 @@ export default function Liquidity() {
                 You can boost your APY to{' '}
                 <span className="text-n3blue font-semibold">
                   {transformNumber(
-                    ((transformNumber(
+                    (((transformNumber(
                       liquidityRewardsAPY ?? 0,
                       NumberType.number
                     ) as number) /
                       10 ** 18) *
-                      potentialBoost,
+                      potentialBoost).toString(),
                     NumberType.number,
                     2
                   ) + '%'}


### PR DESCRIPTION
Fix shortened decimal points in APY boost info

## Related GitHub Issue

#273 

## Screenshots (if appropriate):

![shorten-decimals](https://github.com/nation3/citizen-app/assets/1272158/ada24361-6058-43f1-9dec-10309a35a86a)

## How Has This Been Tested?

- [X] Status checks pass (lint, build, test)
- [X] Works on Sepolia preview deployment
- [ ] Works on Mainnet preview deployment

## Are There Admin Tasks?

<!--- Please include any related admin tasks, like adding/changing environment variables in Vercel. -->
