### PR TITLE
Shorten decimal points in APY boost info 

### DIFF
--- a/ui/lib/numbers.test.ts
+++ b/ui/lib/numbers.test.ts
@@ -1,42 +1,66 @@
 import { describe, expect, test } from '@jest/globals'
 import { BigNumber } from 'ethers'
-import { NumberType, transformNumber, isFixedDecimalsNumber } from './numbers'
+import {
+  NumberType,
+  formatNumberAsPercentage,
+  isFixedDecimalsNumber,
+  transformNumber,
+} from './numbers'
 
 describe('transformNumber', () => {
-  test("transformNumber to Number", () => {
+  test('transformNumber to Number', () => {
     const actual = transformNumber(333, NumberType.number)
     expect(actual).toBe(Number(333))
   })
-  
-  test("transformNumber to BigNumber", () => {
+
+  test('transformNumber to BigNumber', () => {
     const actual = transformNumber(333, NumberType.bignumber)
     expect(actual).toBeInstanceOf(BigNumber)
   })
-  
-  test("transformNumber to String", () => {
+
+  test('transformNumber to String', () => {
     const actual = transformNumber(333, NumberType.string)
-    expect(actual).toBe("333.000000000000000000")
+    expect(actual).toBe('333.000000000000000000')
   })
-  
-  test("transformNumber to String (2 decimals)", () => {
+
+  test('transformNumber to String (2 decimals)', () => {
     const actual = transformNumber(333, NumberType.string, 2)
-    expect(actual).toBe("333.00")
+    expect(actual).toBe('333.00')
   })
 })
 
 describe('isFixedDecimalsNumber', () => {
   test('Is working for integers', () => {
-    const isValid = isFixedDecimalsNumber(12345);
+    const isValid = isFixedDecimalsNumber(12345)
     expect(isValid).toBe(true)
   })
 
   test('Fails for too long decimals', () => {
-    const isValid = isFixedDecimalsNumber('1.111111111111111111111111111111');
+    const isValid = isFixedDecimalsNumber('1.111111111111111111111111111111')
     expect(isValid).toBe(false)
   })
 
-  test('Check "decimals" param is working properly', ()=> {
-    const isValid = isFixedDecimalsNumber(1.12345, 2);
+  test('Check "decimals" param is working properly', () => {
+    const isValid = isFixedDecimalsNumber(1.12345, 2)
     expect(isValid).toBe(false)
+  })
+})
+
+describe.only('formatNumberAsPercentage', () => {
+  describe('toTwoDecimalPlaces', () => {
+    it('should return a number with 2 decimal places for whole numbers', () => {
+      expect(formatNumberAsPercentage(5)).toBe(5.0)
+    })
+
+    it('should return a number with 2 decimal places for decimal numbers', () => {
+      expect(formatNumberAsPercentage(5.1234)).toBe(5.12)
+    })
+
+    it('should return 0.00 when the input is 0', () => {
+      expect(formatNumberAsPercentage(0)).toBe(0.0)
+    })
+    it('should return 1254.09 when the input is 1254.093584459813', () => {
+      expect(formatNumberAsPercentage(1254.093584459813)).toBe(1254.09)
+    })
   })
 })

--- a/ui/lib/numbers.ts
+++ b/ui/lib/numbers.ts
@@ -52,6 +52,10 @@ export function transformNumber(
 export function isFixedDecimalsNumber(value: any, decimals = 18) {
   const NUMBER_REGEX = RegExp(`^(\\d*\\.{0,1}\\d{0,${decimals}}$)`)
   const isValid = value.toString().match(NUMBER_REGEX)
-  
-  return Boolean(isValid);
+
+  return Boolean(isValid)
+}
+
+export function formatNumberAsPercentage(num: any) {
+  return parseFloat(num.toFixed(2))
 }

--- a/ui/pages/liquidity.tsx
+++ b/ui/pages/liquidity.tsx
@@ -1,39 +1,20 @@
-import {
-  ArrowTrendingUpIcon,
-  CurrencyDollarIcon,
-  SparklesIcon,
-  CalculatorIcon,
-  InformationCircleIcon,
-} from '@heroicons/react/24/outline'
-import { useEffect, useState } from 'react'
-import React from 'react'
-import { useBalancerPool } from '../lib/balancer'
-import {
-  balancerPoolId,
-  balancerLPToken,
-  lpRewardsContract,
-  // veNationRewardsMultiplier,
-  balancerDomain,
-} from '../lib/config'
-import {
-  useLiquidityRewards,
-  usePoolTokenBalance,
-  useVeNationBoost,
-  useBoostedAPY,
-  useDeposit,
-  useWithdraw,
-  useWithdrawAndClaim,
-  useClaimRewards,
-} from '../lib/liquidity-rewards'
-import { NumberType, transformNumber } from '../lib/numbers'
-import { useAccount } from '../lib/use-wagmi'
-import { useVeNationBalance, useVeNationSupply } from '../lib/ve-token'
-import ActionButton from '../components/ActionButton'
-import Balance from '../components/Balance'
-import EthersInput from '../components/EthersInput'
-import GradientLink from '../components/GradientLink'
-import Head from '../components/Head'
-import MainCard from '../components/MainCard'
+import { ArrowTrendingUpIcon, CurrencyDollarIcon, SparklesIcon, CalculatorIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+import { useEffect, useState } from 'react';
+import React from 'react';
+import { useBalancerPool } from '../lib/balancer';
+import { balancerPoolId, balancerLPToken, lpRewardsContract, // veNationRewardsMultiplier,
+balancerDomain } from '../lib/config';
+import { useLiquidityRewards, usePoolTokenBalance, useVeNationBoost, useBoostedAPY, useDeposit, useWithdraw, useWithdrawAndClaim, useClaimRewards } from '../lib/liquidity-rewards';
+import { NumberType, formatNumberAsPercentage, transformNumber } from '../lib/numbers';
+import { useAccount } from '../lib/use-wagmi';
+import { useVeNationBalance, useVeNationSupply } from '../lib/ve-token';
+import ActionButton from '../components/ActionButton';
+import Balance from '../components/Balance';
+import EthersInput from '../components/EthersInput';
+import GradientLink from '../components/GradientLink';
+import Head from '../components/Head';
+import MainCard from '../components/MainCard';
+
 
 export default function Liquidity() {
   const { address } = useAccount()
@@ -189,16 +170,9 @@ export default function Liquidity() {
               <div>
                 You can boost your APY to{' '}
                 <span className="text-n3blue font-semibold">
-                  {transformNumber(
-                    ((transformNumber(
-                      liquidityRewardsAPY ?? 0,
-                      NumberType.number
-                    ) as number) /
-                      10 ** 18) *
-                      potentialBoost,
-                    NumberType.number,
-                    2
-                  ) + '%'}
+                  {formatNumberAsPercentage(
+                    (transformNumber(liquidityRewardsAPY ?? 0, NumberType.number) as number / 10**18) * potentialBoost
+                  )+ '%'}
                 </span>
                 . To do so, claim your current rewards.
               </div>


### PR DESCRIPTION
<!--- Please describe what this PR is about here. -->

This is a fix for to shorten decimal points in APY boost information

## Related GitHub Issue

This fix is related to https://github.com/nation3/citizen-app/issues/273

## Screenshots (if appropriate):

<!--- If your pull request changes the UI, please include before/after screenshots. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

- [x] It passes the unit test written for it
- [x] Status checks pass (lint, build, test)
- [x] Works on Sepolia preview deployment 

## Are There Admin Tasks?

No
