### PR TITLE
Stub request to coingecko to not trigger rate limit

### DIFF
--- a/ui/cypress/e2e/liquidity.cy.ts
+++ b/ui/cypress/e2e/liquidity.cy.ts
@@ -1,7 +1,20 @@
 describe('Liquidity', () => {
+  beforeEach(() => {
+    cy.visit('/liquidity')
+
+    cy.intercept("GET", "https://api.coingecko.com/api/v3/simple/price?ids=nation3,ethereum&vs_currencies=usd", {
+      body: {
+        "ethereum": {
+            "usd": 2672.05
+        },
+        "nation3": {
+            "usd": 30.75
+        }
+      },
+    });
+  });
 
   it('stake: type a deposit amount', () => {
-    cy.visit('/liquidity')
 
     // Expect default value to be '0'
     cy.get('#depositValue')
@@ -25,8 +38,7 @@ describe('Liquidity', () => {
   })
 
   it('unstake: type a withdrawal amount', () => {
-    cy.visit('/liquidity')
-
+    
     // Click the "Unstake" tab
     cy.get("#unstakeTab").click()
 


### PR DESCRIPTION
<!--- Please describe what this PR is about here. -->

Stubbing request to coingecko, to not trigger rate limit while testing.

## Related GitHub Issue

<!--- Please link to the GitHub issue here. -->
closes #307 

## Screenshots (if appropriate):

<!--- If your pull request changes the UI, please include before/after screenshots. -->

_Before_ code change:
> ![](<INSERT_SCREENSHOT URL_HERE>)

_After_ code change:
> ![](<INSERT_SCREENSHOT URL_HERE>)

## How Has This Change Been Tested?

<!--- Please describe in detail how you tested your changes. -->


<!-- Tick the checklist for the tests you completed: -->
- [ ] All [status checks](https://github.com/nation3/citizen-app/blob/main/.github/workflows/ui_mainnet.yml#L35) pass (build, lint, e2e, test)
- [ ] Works on Sepolia preview deployment
- [ ] Works on Mainnet preview deployment

## Are Any Admin Tasks Required?

<!--- Please include any related admin tasks, like adding/changing environment variables in Vercel. -->
- [x] No admin tasks
